### PR TITLE
reminder to email username

### DIFF
--- a/.github/workflows/sign-company.yml
+++ b/.github/workflows/sign-company.yml
@@ -1,4 +1,5 @@
-name: Sign CLA for Company Contributor
+name: Company Contributor (No "Run workflow" button? Email username to contact@opendp.org.)
+run-name: Sign CLA for Company Contributor
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sign-individual.yml
+++ b/.github/workflows/sign-individual.yml
@@ -1,4 +1,5 @@
-name: Sign CLA for Individual Contributor
+name: Individual Contributor (No "Run workflow" button? Email username to contact@opendp.org.)
+run-name: Sign CLA for Individual Contributor
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- Fix #15 

I was hoping there would be a `description` field or something like that, but all we have is https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#run-name ... so we can keep the log more concise, while putting more info into the UI.